### PR TITLE
古いtype("int")系実装の完全削除 - PR #4の実装忘れ対応

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -451,21 +451,6 @@ namespace argparse {
                 };
             }
             
-            // 型名から変換器を取得
-            static std::function<AnyValue(const std::string&)> get_converter_by_name(const std::string& type_name) {
-                if (type_name == "int") {
-                    return int_converter();
-                } else if (type_name == "float" || type_name == "double") {
-                    return float_converter();
-                } else if (type_name == "bool") {
-                    return bool_converter();
-                } else if (type_name == "string" || type_name == "str") {
-                    return string_converter();
-                } else {
-                    // 不明な型はデフォルトでstring変換
-                    return string_converter();
-                }
-            }
             
             // カスタム変換器の作成ヘルパー
             template<typename T>
@@ -847,11 +832,6 @@ namespace argparse {
             return *this;
         }
         
-        Argument& type(const std::string& type_name) {
-            definition_.type_name = type_name;
-            _setup_converter_for_type(type_name);
-            return *this;
-        }
         
         template<typename T>
         Argument& type() {
@@ -1059,10 +1039,6 @@ namespace argparse {
             };
         }
         
-        // Setup converter based on type using TypeConverter
-        void _setup_converter_for_type(const std::string& type_name) {
-            definition_.converter = detail::TypeConverter::get_converter_by_name(type_name);
-        }
     };
     
     // ArgumentGroup method implementations (after Argument class definition)

--- a/tests/unit/parser_integration_test.cpp
+++ b/tests/unit/parser_integration_test.cpp
@@ -280,7 +280,7 @@ TEST_F(ParserIntegrationTest, MemoryManagementRAII) {
     {
         argparse::ArgumentParser parser("memory_test");
         parser.add_argument("--large-string").default_value(std::string(10000, 'x'));
-        parser.add_argument("--numbers").type("int").default_value(42);
+        parser.add_argument("--numbers").type<int>().default_value(42);
         
         std::vector<std::string> args = {"--numbers", "999"};
         auto ns = parser.parse_args(args);

--- a/tests/unit/type_converter_test.cpp
+++ b/tests/unit/type_converter_test.cpp
@@ -170,36 +170,6 @@ TEST_F(TypeConverterTest, StringConverter) {
     EXPECT_EQ(converter("special!@#$%^&*()").get<std::string>(), "special!@#$%^&*()");
 }
 
-// get_converter_by_name のテスト
-TEST_F(TypeConverterTest, GetConverterByName) {
-    // int
-    auto int_conv = TypeConverter::get_converter_by_name("int");
-    EXPECT_EQ(int_conv("42").get<int>(), 42);
-    
-    // float
-    auto float_conv = TypeConverter::get_converter_by_name("float");
-    EXPECT_DOUBLE_EQ(float_conv("3.14").get<double>(), 3.14);
-    
-    // double
-    auto double_conv = TypeConverter::get_converter_by_name("double");
-    EXPECT_DOUBLE_EQ(double_conv("2.71").get<double>(), 2.71);
-    
-    // bool
-    auto bool_conv = TypeConverter::get_converter_by_name("bool");
-    EXPECT_TRUE(bool_conv("true").get<bool>());
-    
-    // string
-    auto str_conv = TypeConverter::get_converter_by_name("string");
-    EXPECT_EQ(str_conv("test").get<std::string>(), "test");
-    
-    // str
-    auto str_conv2 = TypeConverter::get_converter_by_name("str");
-    EXPECT_EQ(str_conv2("test").get<std::string>(), "test");
-    
-    // 未知の型名 -> デフォルトでstring変換
-    auto unknown_conv = TypeConverter::get_converter_by_name("unknown_type");
-    EXPECT_EQ(unknown_conv("test").get<std::string>(), "test");
-}
 
 // テンプレート特殊化のテスト
 TEST_F(TypeConverterTest, GetConverterTemplate) {


### PR DESCRIPTION
## 概要

#4 で実装された`type<int>()`テンプレートメソッドの移行において、古い文字列ベースの`type("int")`実装が残っていたため、これを完全削除しました。

## 問題

変更ログ（`.spec-workflow/specs/argparse-core/changelog/2025-09-10-BREAKING-type-template-method.md`）で報告された破壊的変更が完了しておらず、以下の古い実装が`include/argparse/argparse.hpp`に残存していました：

- `Argument::type(const std::string& type_name)` - 文字列ベースの型指定メソッド
- `_setup_converter_for_type()` - 文字列型名からコンバーター設定
- `TypeConverter::get_converter_by_name()` - 文字列型名からコンバーター取得

## 修正内容

### ✨ 削除した実装

1. **Argumentクラス**:
   ```cpp
   // 削除: 文字列ベース型指定（847-851行目）
   Argument& type(const std::string& type_name);
   
   // 削除: 内部実装（1058-1060行目）
   void _setup_converter_for_type(const std::string& type_name);
   ```

2. **TypeConverterクラス**:
   ```cpp
   // 削除: 文字列型名コンバーター（455-468行目）
   static std::function<AnyValue(const std::string&)> get_converter_by_name(const std::string& type_name);
   ```

3. **テストケース**:
   - `GetConverterByName`テストを削除（tests/unit/type_converter_test.cpp:174-202行目）
   - テスト内の`.type("int")`を`.type<int>()`に修正

### 🔒 現在利用可能なAPI

```cpp
// ✅ 新しいテンプレート形式のみ利用可能
parser.add_argument("--count").type<int>();
parser.add_argument("--rate").type<double>();
parser.add_argument("--name").type<std::string>();
parser.add_argument("--enable").type<bool>();

// ❌ 古い文字列形式は完全に削除済み
// parser.add_argument("--count").type("int");  // コンパイルエラー
```

## 検証結果

- ✅ **ビルド成功**: 全21テストのビルド完了
- ✅ **テスト通過**: 21/21テスト成功（100%通過率）
- ✅ **破壊的変更なし**: 既存のテンプレート形式の機能に影響なし
- ✅ **実装の一貫性**: 文字列ベースと新形式の混在を解消

## 関連Issue

#3 
#4 （実装忘れ）

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>