### PR TITLE
fix: auto-releaseワークフローのsedエラーを修正

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -91,29 +91,23 @@ jobs:
           echo "Generating changelog..."
           
           if [ -n "$LATEST_TAG" ]; then
-            # Get commits since last release
-            CHANGELOG=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
+            # Get commits since last release - save to temp file to avoid shell issues
+            git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges > changelog_temp.txt
             
-            if [ -z "$CHANGELOG" ]; then
-              CHANGELOG="- No notable changes since last release"
+            if [ ! -s changelog_temp.txt ]; then
+              echo "- No notable changes since last release" > changelog_temp.txt
             fi
           else
             # First release - get all commits
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges | head -20)
+            git log --pretty=format:"- %s (%h)" --no-merges | head -20 > changelog_temp.txt
           fi
           
-          # Format changelog for GitHub
-          cat > changelog.md << 'EOF'
-          ## What's Changed
-          
-          $CHANGELOG
-          
-          **Full Changelog**: https://github.com/${{ github.repository }}/commits/v$CURRENT_VERSION
-          EOF
-          
-          # Replace variables in changelog
-          sed -i "s|\$CHANGELOG|$CHANGELOG|g" changelog.md
-          sed -i "s|\$CURRENT_VERSION|$CURRENT_VERSION|g" changelog.md
+          # Format changelog for GitHub - safe method without variable substitution
+          echo "## What's Changed" > changelog.md
+          echo "" >> changelog.md
+          cat changelog_temp.txt >> changelog.md
+          echo "" >> changelog.md
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/v$CURRENT_VERSION" >> changelog.md
           
           echo "Generated changelog:"
           cat changelog.md


### PR DESCRIPTION
## 概要

auto-releaseワークフローで発生していた`sed`エラーを修正します。

## 問題

PR #8で導入したauto-releaseワークフローが以下のエラーで失敗していました：

```
sed: -e expression #1, char 96: unterminated 's' command
```

**失敗したワークフロー**: [Run #17603301677](https://github.com/ph2684/argparse-cpp/actions/runs/17603301677)

## 原因

changelog生成時に`sed`コマンドで変数置換を行う際、コミットメッセージに含まれる特殊文字（`/`, `'`, `"`, 改行等）が`sed`の区切り文字と衝突していました。

```bash
# 問題のあるコード
sed -i "s|\$CHANGELOG|$CHANGELOG|g" changelog.md
```

## 解決策

### ✅ 修正内容
- **sed による変数置換を廃止**
- **直接ファイル操作でchangelog.mdを生成**
- **一時ファイル使用**で特殊文字を安全に処理

```bash
# 修正後のコード  
git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges > changelog_temp.txt
echo "## What's Changed" > changelog.md
cat changelog_temp.txt >> changelog.md
```

### 🔒 安全性の向上
- 特殊文字によるコマンドインジェクションを防止
- シェル変数展開の問題を回避
- より確実なchangelog生成処理

## テスト

この修正により、以下のような問題のあるコミットメッセージでもワークフローが正常に動作します：
- `fix: "quoted strings" and /path/names`
- `feat: multi-line\ncommit messages`
- `docs: special chars like $VAR and \`code\``

## 関連PR

- PR #8: 手動バージョン管理システム導入（sedエラーの原因）

🤖 Generated with [Claude Code](https://claude.ai/code)